### PR TITLE
attempt to accept multiple 'upstream' servers in nginx.conf

### DIFF
--- a/root/docker-entrypoint.d/configure-lb.sh
+++ b/root/docker-entrypoint.d/configure-lb.sh
@@ -2,20 +2,21 @@
 
 set -o nounset
 set -o errexit
-set -o pipefail
+# set -o pipefail
 
-NGINX_CONF=/etc/nginx/nginx.conf
+# NGINX_CONF=/etc/nginx/nginx.conf
 
 main() {
   LB_PORT=${LB_PORT:-80}
-  LB_BACKENDS=${LB_BACKENDS:-example.com:80}
+  lb_backends=$(echo  ${LB_BACKENDS} | tr "," "\n") #split comma delimited string
 
   # Complete the nginx.conf template
   UPSTREAM_BACKENDS=""
-  for i in $(echo $LB_BACKENDS | sed 's|;| |g') ; do
-    UPSTREAM_BACKENDS="$UPSTREAM_BACKENDS   server $$i;\n"
+  for i in $(echo $lb_backends | sed 's|;| |g') ; do
+    UPSTREAM_BACKENDS="$UPSTREAM_BACKENDS   server $i;\n"
   done
 
+  # echo $UPSTREAM_BACKENDS
   sed -i "s|__LB_PORT__|${LB_PORT}|" "${NGINX_CONF}"
   sed -i "s|__UPSTREAM_BACKENDS__|${UPSTREAM_BACKENDS}|" "${NGINX_CONF}"
 


### PR DESCRIPTION
@erwinvaneyk I still haven't tested this but the idea is that  when we pass "localhost:6443,localhost:10250" the nginx.conf will be generated something like:

```
    upstream backend {
      localhost:6443 server1
     localhost:10250 server2
    }
```


Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>